### PR TITLE
introducing a github and a Bioc package installation

### DIFF
--- a/rstudio/bioc_3.9/install.R
+++ b/rstudio/bioc_3.9/install.R
@@ -23,4 +23,6 @@ for (builtin in builtins)
 install.packages(c("bigrquery", "googleCloudStorageR"),
                  repos="http://cran.mtu.edu")
 
-devtools::install_github("DataBiosphere/Ronaldo")
+devtools::install_github("DataBiosphere/Ronaldo", "vjcitn/tumex5")
+
+BiocManager::install("BiocOncoTK")


### PR DESCRIPTION
vjcitn/tumex5 is support for using HSDS to get expression data on 5 TCGA tumor types.
BiocOncoTK is introduced to get access to the bindMSI function.